### PR TITLE
fix: resolve desktop title overlapping cards in LatestProjectsAlt sec…

### DIFF
--- a/src/components/section/landing/LatestProjectsAlt.astro
+++ b/src/components/section/landing/LatestProjectsAlt.astro
@@ -79,7 +79,7 @@ const sortedWorks = allworks.sort(
     class="projects-wrapper hidden md:block bg-smokyBlack w-full h-[calc(100vh-8rem)] p-8 relative"
   >
     <div
-      class="desktop-title hidden md:flex absolute top-25 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 items-center justify-center mb-8"
+      class="desktop-title hidden md:flex absolute top-8 left-1/2 transform -translate-x-1/2 z-10 items-center justify-center mb-8"
     >
       <h1 class="text-smokyBlack font-playfair font-bold text-6xl">
         Proyectos recientes
@@ -88,7 +88,7 @@ const sortedWorks = allworks.sort(
     <div
       class="projects-container flex rounded-lg w-[80vw] mx-auto bg-softBeige h-full items-center overflow-hidden relative"
     >
-      <div class="projects-inner flex mt-12">
+      <div class="projects-inner flex mt-20">
         {
           sortedWorks.map((project, index) => (
             <div


### PR DESCRIPTION
…tion

- Changed title position from top-25 to top-8 to prevent overlap
- Increased projects-inner margin from mt-12 to mt-20 for better spacing
- Removed -translate-y-1/2 transform to ensure proper positioning
- Fixes visual overlap issue on desktop screens