### PR TITLE
feat: update contact form to use custom domain email

### DIFF
--- a/src/actions/contact/getContact.ts
+++ b/src/actions/contact/getContact.ts
@@ -20,7 +20,7 @@ export const getContact = defineAction({
       console.log('Attempting to send email with Resend...');
       
       const { data, error } = await resend.emails.send({
-        from: 'Shine <shine@resend.dev>',
+        from: 'Shine <noreply@shineagencia.com>',
         to: ['diego.shineagencia@gmail.com'],
         subject: 'Nuevo contacto desde la web',
         html: `


### PR DESCRIPTION
- Change sender email from shine@resend.dev to noreply@shineagencia.com
- Improves email deliverability and professional appearance
- Uses verified custom domain for better brand consistency