### PR TITLE
feat: add Google Tag Manager tracking to main layout

### DIFF
--- a/src/layout/MainLayout.astro
+++ b/src/layout/MainLayout.astro
@@ -65,6 +65,13 @@ const allSchemas: JSONLDSchema[] = [...baseSchemas, ...aditionalSchemas];
 
 			gtag('config', 'G-2PQK7CZ132');
 		</script>
+
+		<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-KWDKMGBL');</script>
 		
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
@@ -95,6 +102,9 @@ const allSchemas: JSONLDSchema[] = [...baseSchemas, ...aditionalSchemas];
 		</script>
 	</head>
 	<body class="w-full p-0 m-0 overflow-x-hidden">
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KWDKMGBL"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 		<BgTexture />
 		<CursorFollower />
 		<NavBarAlt />


### PR DESCRIPTION
- Add GTM script to head section with container ID GTM-KWDKMGBL
- Include noscript fallback iframe in body for users with JavaScript disabled
- Positioned after existing Google Analytics script for proper load order