### PR TITLE
refactor: remove focusKeyword dependency from service SEO configuration

### DIFF
--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -8,19 +8,19 @@ export type JSONLDSchema = Record<string, any>;
 export const COMPANY_INFO = {
   name: 'Shine',
   description: 'Transformamos tu presencia digital con estrategia, propósito y autenticidad. Diseño web, marketing digital y contenido que refleja tu verdadera esencia.',
-  url: 'https://shineagencia.com', // Replace with your actual domain
-  phone: '+57-3162560670', // Replace with actual phone
-  email: 'rocio.shineagencia@gmail.com', // Replace with actual email
+  url: 'https://shineagencia.com', // Replace with current domain
+  phone: '+57-3162560670', // Replace with current phone
+  email: 'rocio.shineagencia@gmail.com', // Replace with current email
   address: {
-    street: 'Bogotá, Colombia', // Replace with actual address
+    street: 'Bogotá, Colombia', // Replace with current address
     city: 'Bogotá',
     region: 'Cundinamarca',
-    postalCode: '110111', // Replace with actual postal code
+    postalCode: '110111', // Replace with current postal code
     country: 'Colombia'
   },
-  logo: '/images/shine-logo.svg', // Replace with actual logo path
-  image: '/images/shine-og-image.png', // Replace with actual OG image path
-  foundingDate: '2025', // Replace with actual founding date
+  logo: '/images/shine-logo.svg', // Replace with current logo path
+  image: '/images/shine-og-image.png', // Replace with current OG image path
+  foundingDate: '2025', // Replace with current founding date
   founders: ['Rocío', 'Diego'],
   socialMedia: {
     instagram: 'https://www.instagram.com/rochi.diego',

--- a/src/config/services.ts
+++ b/src/config/services.ts
@@ -31,7 +31,6 @@ export interface Service {
     seoDescription: string;
     seoKeywords: string[]; // Primary keywords for meta tags
     secondaryKeywords?: string[]; // Secondary/long-tail keywords for content optimization
-    focusKeyword: string;
 }
 
 export const services: Service[] = [
@@ -108,7 +107,6 @@ export const services: Service[] = [
       "atraer clientes de alto valor",
       "crear contenido que vende"
     ],
-    focusKeyword: "estrategia de marca personal y contenidos"
   },
   {
     slug: "diseno-web-estrategico",
@@ -180,7 +178,6 @@ export const services: Service[] = [
       "mejorar velocidad de carga de mi nueva web",
       "diseño web para startups en Colombia"
     ],
-    focusKeyword: "diseño web con Astro Framework"
   },
   {
     slug: "rediseño-web-estrategico",
@@ -261,7 +258,6 @@ export const services: Service[] = [
       "agencia de optimización web",
       "optimización de la experiencia de usuario (UX)"
     ],
-    focusKeyword: "optimización web estratégica"
   }
 ]
 


### PR DESCRIPTION
- Remove focusKeyword field from Service interface (no longer needed)
- Clean up service objects by removing unused focusKeyword properties
- Simplify SEO title generation to use only service.title and brand name
- Maintain consistent title format: "Service Title | Shine" (43-49 chars)
- Ensure all service page titles remain under 60 characters for Google compliance