### PR TITLE
fix: resolve active link styling issue in navigation components

### DIFF
--- a/src/components/global/Footer.astro
+++ b/src/components/global/Footer.astro
@@ -9,7 +9,11 @@ import ArrowUpIcon from "@/assets/icons/arrowUp.svg";
 import WhatsAppIcon from "@/assets/icons/whatsapp.svg";
 import Button from "@/components/ui/button.astro";
 import DropdownIcon from "@/assets/icons/dropdown.svg";
-const currentPath = Astro.url.pathname;
+const currentPathRaw = decodeURIComponent(Astro.url.pathname);
+const currentPath =
+  currentPathRaw !== "/" && currentPathRaw.endsWith("/")
+    ? currentPathRaw.slice(0, -1)
+    : currentPathRaw;
 ---
 
 <footer class="w-full border-t border-softBeige/5 bg-smokyBlack relative mt-20">

--- a/src/components/global/NavbarAlt.astro
+++ b/src/components/global/NavbarAlt.astro
@@ -9,7 +9,11 @@ import Rocket from "@/assets/images/rocket.webp";
 import DropdownIcon from "@/assets/icons/dropdown.svg";
 
 import { navBarLinksConst, servicesLinksConst } from "@/utils/navigation";
-const currentPath = Astro.url.pathname;
+const currentPathRaw = decodeURIComponent(Astro.url.pathname);
+const currentPath =
+  currentPathRaw !== "/" && currentPathRaw.endsWith("/")
+    ? currentPathRaw.slice(0, -1)
+    : currentPathRaw;
 ---
 
 <header class="nav-container fixed top-0 z-50 mx-auto w-full">


### PR DESCRIPTION
Fixed underline not appearing on active service links in production by normalizing URL paths. The issue occurred due to trailing slash mismatch and URL encoding of special characters (ñ) in service paths.

Changes:
- Decode URL-encoded paths using decodeURIComponent
- Normalize paths by removing trailing slashes
- Apply fix to both NavbarAlt and Footer components
- Ensures consistent path comparison across all navigation links