### PR TITLE
fix: resolve theme toggle functionality on mobile and improve resposive layout

### DIFF
--- a/src/components/global/NavbarAlt.astro
+++ b/src/components/global/NavbarAlt.astro
@@ -205,7 +205,7 @@ const currentPath =
   </nav>
   <!-- Menu Button and Theme Toggle -->
   <div class="absolute top-6 right-6 lg:right-16 items-center flex gap-4 z-50">
-    <div class="lg:hidden">
+    <div class="lg:hidden z-50 relative opacity-100">
       <ThemeToggle />
     </div>
     <button

--- a/src/components/section/landing/LatestProjectsAlt.astro
+++ b/src/components/section/landing/LatestProjectsAlt.astro
@@ -14,7 +14,7 @@ const sortedWorks = allworks.sort(
 <section
   class="projects-section relative section w-full bg-softWhite dark:bg-smokyBlack px-4 py-4 md:py-16 md:px-0"
 >
-  <!-- Title - Mobile only -->
+  <!-- Title - Mobile and Tablet -->
   <div class="flex flex-col items-center justify-center text-center gap-4 mb-8">
     <div class="flex items-center">
       <Button
@@ -27,29 +27,29 @@ const sortedWorks = allworks.sort(
       </Button>
     </div>
     <h1
-      class="text-smokyBlack dark:text-softWhite font-playfair font-medium text-3xl md:hidden"
+      class="text-smokyBlack dark:text-softWhite font-playfair font-medium text-3xl lg:hidden"
     >
       Proyectos recientes
     </h1>
   </div>
 
-  <!-- Mobile Cards -->
-  <div class="md:hidden">
+  <!-- Mobile and Tablet Cards -->
+  <div class="lg:hidden p-16">
     {
       sortedWorks.map((project) => (
         <div class="mb-8">
-          <div class="bg-softWhite rounded-lg overflow-hidden shadow-lg h-[500px] flex flex-col">
-            <div class="flex-1 p-6 flex items-center justify-center bg-gray-50">
+          <div class="bg-softWhite dark:bg-smokyBlack dark:border dark:border-softWhite/35 dark:shadow-xl dark:shadow-softWhite/5 rounded-lg overflow-hidden shadow-xl h-[500px] flex flex-col">
+            <div class="flex-1 p-6 flex items-center justify-center bg-gray-50 dark:bg-smokyBlack/50">
               <div class="w-full max-w-xs">
                 <ProjectCardAlt project={project} className="w-full" />
               </div>
             </div>
-            <div class="p-6 bg-softWhite">
+            <div class="p-6 bg-softWhite dark:bg-smokyBlack">
               <div class="flex justify-between items-baseline mb-4">
-                <h2 class="text-smokyBlack font-playfair font-medium text-lg">
+                <h2 class="text-smokyBlack dark:text-softWhite font-playfair font-medium text-lg">
                   {project.data.title}
                 </h2>
-                <span class="text-smokyBlack font-playfair font-bold text-2xl">
+                <span class="text-smokyBlack dark:text-softWhite font-playfair font-bold text-2xl">
                   {project.data.pubDate.getFullYear()}
                 </span>
               </div>
@@ -81,10 +81,10 @@ const sortedWorks = allworks.sort(
 
   <!-- Desktop Horizontal Scroll -->
   <div
-    class="projects-wrapper hidden md:block bg-smokyBlack w-full h-[calc(100vh-8rem)] p-8 relative"
+    class="projects-wrapper hidden lg:block bg-smokyBlack dark:bg-smokyBlack w-full h-[calc(100vh-8rem)] p-8 relative"
   >
     <div
-      class="desktop-title hidden md:flex absolute top-8 left-1/2 transform -translate-x-1/2 z-10 items-center justify-center mb-8"
+      class="desktop-title hidden lg:flex absolute top-8 left-1/2 transform -translate-x-1/2 z-10 items-center justify-center mb-8"
     >
       <h1 class="text-smokyBlack font-playfair font-bold text-6xl">
         Proyectos recientes

--- a/src/components/ui/ThemeToggle.astro
+++ b/src/components/ui/ThemeToggle.astro
@@ -3,15 +3,14 @@
 ---
 
 <button
-  id="theme-toggle"
   type="button"
   aria-label="Toggle dark mode"
-  class="p-2 rounded-full hover:scale-110 dark:hover:scale-110 transition-all duration-200"
+  class="theme-toggle-btn p-2 rounded-full hover:scale-110 dark:hover:scale-110 transition-all duration-200"
+  onclick="window.toggleTheme?.()"
 >
   <!-- Sun Icon (visible in dark mode) -->
   <svg
-    id="sun-icon"
-    class="hidden dark:block w-6 h-6 text-yellow-500"
+    class="sun-icon hidden dark:block w-6 h-6 text-yellow-500"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
@@ -27,8 +26,7 @@
 
   <!-- Moon Icon (visible in light mode) -->
   <svg
-    id="moon-icon"
-    class="block dark:hidden w-6 h-6 text-smokyBlack"
+    class="moon-icon block dark:hidden w-6 h-6 text-smokyBlack"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
   >
@@ -40,34 +38,41 @@
   </svg>
 </button>
 
-<script>
-  function initThemeToggle() {
-    const toggle = document.getElementById("theme-toggle");
-    if (!toggle) return;
+<script is:inline>
+  // Make toggle function globally available
+  window.toggleTheme = function() {
+    const isDark = document.documentElement.classList.contains("dark");
+    const newTheme = isDark ? "light" : "dark";
 
-    // Handle toggle click
-    toggle.addEventListener("click", () => {
-      const isDark = document.documentElement.classList.contains("dark");
-      const newTheme = isDark ? "light" : "dark";
+    if (isDark) {
+      document.documentElement.classList.remove("dark");
+      localStorage.theme = "light";
+    } else {
+      document.documentElement.classList.add("dark");
+      localStorage.theme = "dark";
+    }
 
-      if (isDark) {
-        // Switch to light mode
-        document.documentElement.classList.remove("dark");
-        localStorage.theme = "light";
-      } else {
-        // Switch to dark mode
-        document.documentElement.classList.add("dark");
-        localStorage.theme = "dark";
-      }
+    // Dispatch custom event for theme-aware animations
+    window.dispatchEvent(new CustomEvent("themechange", { detail: { theme: newTheme } }));
+  };
 
-      // Dispatch custom event for theme-aware animations
-      window.dispatchEvent(new CustomEvent("themechange", { detail: { theme: newTheme } }));
+  // Initialize theme toggles with event delegation
+  function initThemeToggles() {
+    document.querySelectorAll(".theme-toggle-btn").forEach((btn) => {
+      // Remove inline onclick to prevent double-firing
+      btn.removeAttribute("onclick");
+      // Add event listener
+      btn.addEventListener("click", window.toggleTheme);
     });
   }
 
-  // Run on initial page load
-  initThemeToggle();
+  // Initialize on DOM ready
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initThemeToggles);
+  } else {
+    initThemeToggles();
+  }
 
-  // Re-run after Astro view transitions (if added later)
-  document.addEventListener("astro:page-load", initThemeToggle);
+  // Re-initialize after Astro view transitions
+  document.addEventListener("astro:page-load", initThemeToggles);
 </script>


### PR DESCRIPTION


- Fix theme toggle not working on mobile by using class-based selectors instead of IDs
- Add global window.toggleTheme function with inline onclick fallback
- Ensure mobile theme toggle is always visible with explicit z-index and opacity
- Update responsive breakpoints for project cards (mobile/tablet: lg:hidden, desktop: lg:block)
- Add comprehensive dark mode support to project cards with borders and shadows