### PR TITLE
fix: sanitize blog post slugs to prevent URL encoding issues

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -16,19 +16,22 @@ interface Props {
 
 const { title, description, publishDate, image, slug } = Astro.props;
 
+// Sanitize slug: trim whitespace and ensure it's URL-safe
+const sanitizedSlug = slug.trim().replace(/\s+/g, '-').toLowerCase();
+
 // Generate specific schemas for the post
 const postSchema = generateBlogPostSchema({
     title,
     description,
     publishDate,
     image,
-    id: slug,
+    id: sanitizedSlug,
 });
 
 const breadcrumbSchema = generateBreadcrumbSchema([
     { name: "Inicio", url: "/" },
     { name: "Blog", url: "/blog" },
-    { name: title, url: `/blog/${slug}` },
+    { name: title, url: `/blog/${sanitizedSlug}` },
 ]);
 
 const aditionalSchemas: JSONLDSchema[] = [postSchema, breadcrumbSchema];
@@ -37,7 +40,7 @@ const aditionalSchemas: JSONLDSchema[] = [postSchema, breadcrumbSchema];
 <MainLayout
     title={title}
     description={description}
-    path={`/blog/${slug}`}
+    path={`/blog/${sanitizedSlug}`}
     image={image}
     aditionalSchemas={aditionalSchemas}
 >


### PR DESCRIPTION
- Add slug sanitization in PostLayout to trim whitespace and convert to URL-safe format
- Fix canonical URLs showing %20 encoded spaces
- Ensure consistent slug formatting across breadcrumbs and schemas