### PR TITLE
feat(seo): add FAQ and HowTo schemas with AI crawler support

### DIFF
--- a/src/components/global/NavbarAlt.astro
+++ b/src/components/global/NavbarAlt.astro
@@ -85,11 +85,11 @@ const currentPath =
           </ul>
         </div>
       </div>
-      <a
+      <!--<a
         href="/blog"
         class={`text-smokyBlack dark:text-softWhite text-lg font-openSans font-semibold rounded-4xl hover:bg-salviaGreen py-2 px-4 hover:rounded-4xl hover:text-softWhite transition-colors duration-200 ${currentPath === "/blog" ? "bg-salviaGreen text-softWhite" : ""}`}
         aria-current={currentPath === "/blog" ? "page" : undefined}>Blog</a
-      >
+      > -->
       <a
         href="/contacto"
         class={`text-smokyBlack dark:text-softWhite text-lg font-openSans font-semibold rounded-4xl hover:bg-salviaGreen py-2 px-4 hover:rounded-4xl hover:text-softWhite transition-colors duration-200 ${currentPath === "/contacto" ? "bg-salviaGreen text-softWhite" : ""}`}

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,7 +1,27 @@
 import type { APIRoute } from 'astro';
 
 const getRobotsTxt = (sitemapURL: URL) => `
+# All crawlers
 User-agent: *
+Allow: /
+
+# AI Crawlers - Critical for visibility in ChatGPT, Gemini, Perplexity
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
 Allow: /
 
 Sitemap: ${sitemapURL.href}
@@ -9,5 +29,10 @@ Sitemap: ${sitemapURL.href}
 
 export const GET: APIRoute = ({ site }) => {
   const sitemapURL = new URL('sitemap-index.xml', site);
-  return new Response(getRobotsTxt(sitemapURL));
+
+  return new Response(getRobotsTxt(sitemapURL), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
 };


### PR DESCRIPTION
- Add FAQPage schema generator for rich snippets and AI citation
- Add HowTo schema generator for step-by-step content
- Update robots.txt to allow GPTBot, ClaudeBot, PerplexityBot, and other AI crawlers
- Add proper Content-Type header to robots.txt response