### PR TITLE
fix: change h1 to h3 in ServiceCard for semantic HTML

### DIFF
--- a/src/components/ui/ServiceCard.astro
+++ b/src/components/ui/ServiceCard.astro
@@ -38,9 +38,9 @@ const { slug, image, alt, title, description, tags } = Astro.props;
             ))
           }
         </div>
-        <h1 class="text-lg font-semibold line-clamp-2 dark:text-softWhite">
+        <h3 class="text-lg font-semibold line-clamp-2 dark:text-softWhite">
           {title}
-        </h1>
+        </h3>
       </div>
       <p
         class="description text-sm text-deepplum dark:text-softWhite mt-2 line-clamp-3"


### PR DESCRIPTION
fix: change h1 to h3 in ServiceCard for semantic HTML" --body "This PR fixes a semantic HTML issue in the ServiceCard component by changing the heading level from an \`h1\` to an \`h3\`, ensuring proper document outline hierarchy."