### PR TITLE
fix: align robots.txt AI crawler policy with Cloudflare edge rules

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,40 +1,33 @@
 import type { APIRoute } from 'astro';
 
-const getRobotsTxt = (sitemapURL: URL, siteURL: URL) => `
+const getRobotsTxt = (sitemapURL: URL) => `
 # All crawlers
 User-agent: *
 Allow: /
 
-# AI Crawlers - Critical for visibility in ChatGPT, Gemini, Perplexity
-User-agent: GPTBot
+# AI search/retrieval bots - allowed so AI engines can cite this site.
+# Training bots (GPTBot, ClaudeBot, Google-Extended, CCBot, etc.) are
+# opted out at the Cloudflare edge, not here - do not re-allow them
+# in this file or it creates a conflicting duplicate rule.
+User-agent: OAI-SearchBot
 Allow: /
 
-User-agent: ChatGPT-User
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: Google-Extended
+User-agent: Claude-SearchBot
 Allow: /
 
 User-agent: PerplexityBot
 Allow: /
 
-User-agent: CCBot
+User-agent: ChatGPT-User
 Allow: /
-
-# LLM Content Discovery
-Llms-Txt: ${siteURL.href}llms.txt
 
 Sitemap: ${sitemapURL.href}
 `;
 
 export const GET: APIRoute = ({ site }) => {
   const sitemapURL = new URL('sitemap-index.xml', site);
-  const siteURL = new URL('/', site);
 
-  return new Response(getRobotsTxt(sitemapURL, siteURL), {
+  return new Response(getRobotsTxt(sitemapURL), {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',
     },


### PR DESCRIPTION
## Summary
- Remove Allow: / directives for training bots (GPTBot, ClaudeBot, Google-Extended, CCBot) that conflict with Cloudflare's Disallow rules
- Add explicit entries for citation bots (OAI-SearchBot, Claude-SearchBot) to document retrieval-vs-training intent  
- Remove non-standard Llms-Txt: directive from robots.txt
- Add comment explaining why training bots are managed at Cloudflare edge, not in code

## Why
Cloudflare was injecting a conflicting Disallow rule before the custom robots.txt rules, creating parsing ambiguity. This aligns the code to rely on Cloudflare's edge policy for training bots while making citation bots explicit in code.

## Verification
- Build validation: `pnpm build` ✓
- robots.txt generated correctly in dist/